### PR TITLE
下にスクロールするたびに次の20件を読み込むようにした。

### DIFF
--- a/lib/Screens/article_list_screen.dart
+++ b/lib/Screens/article_list_screen.dart
@@ -19,52 +19,103 @@ class ArticleListScreen extends StatefulWidget {
 }
 
 class _ArticleListScreenState extends State<ArticleListScreen> {
+  var _currentPage = 1;
+  List<Article> _articleList = [];
+  Object? _error;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadArticleList(1);
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Column(
-        children: [
-          Expanded(
-            child: Container(
-              padding: const EdgeInsets.all(8),
-              child: FutureBuilder<List<Article>>(
-                  future: QiitaRepository().fetchArticleList(
-                    searchText: widget.searchString,
-                    tagID: widget.tagID,
-                  ),
-                  builder: (context, snapshot) {
-                    if (snapshot.hasData) {
-                      List<Article> articleList = snapshot.data!;
+    if (_error != null) {
+      return Center(
+        child: Text(_error.toString()),
+      );
+    }
 
-                      return ListView(
-                        children: articleList.map((article) {
-                          return Material(
-                            child: InkWell(
-                              onTap: () {
-                                Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (_) => ArticleScreen(
-                                      article: article,
-                                    ),
-                                  ),
-                                );
-                              },
-                              child: articleCard(
-                                title: article.title,
-                                author: article.user.id,
-                                profileImageIcon: article.user.profileImageUrl,
-                              ),
-                            ),
-                          );
-                        }).toList(),
-                      );
-                    } else {
-                      return const Text("not found API data");
-                    }
-                  }),
+    if (_articleList != null) {
+      return _articleListView(
+        articleList: _articleList,
+        onTapArticle: (Article article) {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => ArticleScreen(article: article)),
+          );
+        },
+        onScrollEnd: () {
+          if (_isLoading == false) {
+            _loadArticleList(_currentPage + 1);
+          }
+        },
+      );
+    }
+
+    return const Center(
+      child: CircularProgressIndicator(),
+    );
+  }
+
+  void _loadArticleList(int page) {
+    QiitaRepository().fetchArticleList(page: page).then((value) {
+      setState(() {
+        if (page == 1) {
+          _articleList = value;
+        } else {
+          _articleList.addAll(value);
+        }
+        _currentPage = page;
+      });
+    }).catchError((e) {
+      setState(() {
+        _error = e;
+      });
+    }).whenComplete(() {
+      _isLoading = false;
+    });
+    _isLoading = true;
+  }
+}
+
+class _articleListView extends StatelessWidget {
+  final List<Article> articleList;
+  final Function(Article article) onTapArticle;
+  final Function() onScrollEnd;
+
+  const _articleListView({
+    Key? key,
+    required this.articleList,
+    required this.onTapArticle,
+    required this.onScrollEnd,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification.metrics.extentAfter == 0.0) {
+          onScrollEnd();
+        }
+        return true;
+      },
+      child: ListView.builder(
+        itemBuilder: (context, index) {
+          final Article article = articleList[index];
+          return InkWell(
+            onTap: () => onTapArticle(article),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: articleCard(
+                  title: article.title,
+                  author: article.user.id,
+                  profileImageIcon: article.user.profileImageUrl),
             ),
-          )
-        ],
+          );
+        },
+        itemCount: articleList.length,
       ),
     );
   }


### PR DESCRIPTION
futureBuilderを使って20件読み込んでいたが、下スクロールは無理そうだった＋Qiitaの仕様では一度に20件~100件ほどしか読み込めず、全てを表示させるにはページ指定が必須なこともあり、`NotificationListener<ScrollNotification>`で下スクロールしたときの通知を受け取って`page+1`することにした。

また、情報を取得中にローディング画面を出す、エラーになった際にはエラーメッセージを出すようにした。