### PR TITLE
ログインしていないユーザーのプロフィールにログインボタンを表示させた

### DIFF
--- a/lib/Screens/home_screen.dart
+++ b/lib/Screens/home_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:qiitaapp/Repository/qiita_repository.dart';
-import 'package:qiitaapp/Screens/top_screen.dart';
-import 'package:qiitaapp/Screens/user_profile_screen.dart';
+import 'package:qiitaapp/screens/top_screen.dart';
+import 'package:qiitaapp/screens/user_profile_screen.dart';
 import 'package:qiitaapp/screens/search_screen.dart';
 import 'package:qiitaapp/screens/stock_screen.dart';
 import 'package:qiitaapp/screens/tag_screen.dart';
@@ -40,24 +40,40 @@ class _HomeScreenState extends State<HomeScreen> {
                       profileImageUrl: snapshot.data.profileImageUrl,
                     )
                   : const Icon(Icons.person);
+              if (snapshot.hasData) {
+                PopupMenuButton(
+                  onSelected: (value) {
+                    if (value == 'profile') {
+                      _onProfileMenuIsSelected(snapshot.data);
+                    } else {
+                      _onLogoutMenuIsSelected();
+                    }
+                  },
+                  icon: icon,
+                  itemBuilder: (context) {
+                    return [
+                      const PopupMenuItem(
+                        value: 'profile',
+                        child: Text("プロフィール"),
+                      ),
+                      const PopupMenuItem(
+                        value: 'logout',
+                        child: Text("ログアウト"),
+                      ),
+                    ];
+                  },
+                );
+              }
               return PopupMenuButton(
                 onSelected: (value) {
-                  if (value == 'profile') {
-                    _onProfileMenuIsSelected(snapshot.data);
-                  } else {
-                    _onLogoutMenuIsSelected();
-                  }
+                  _onSignInMenuIsSelected();
                 },
                 icon: icon,
                 itemBuilder: (context) {
                   return [
                     const PopupMenuItem(
-                      value: 'profile',
-                      child: Text("プロフィール"),
-                    ),
-                    const PopupMenuItem(
-                      value: 'logout',
-                      child: Text("ログアウト"),
+                      value: 'SignIn',
+                      child: Text("ログインする"),
                     ),
                   ];
                 },
@@ -96,6 +112,12 @@ class _HomeScreenState extends State<HomeScreen> {
   void _onLogoutMenuIsSelected() async {
     await QiitaRepository().revokeSavedAccessToken();
     await QiitaRepository().deleteAccessToken();
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const TopScreen()),
+    );
+  }
+
+  void _onSignInMenuIsSelected() async {
     Navigator.of(context).pushReplacement(
       MaterialPageRoute(builder: (_) => const TopScreen()),
     );

--- a/lib/Screens/stock_screen.dart
+++ b/lib/Screens/stock_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:qiitaapp/models/articles.dart';
-import 'package:qiitaapp/Models/user.dart';
+import 'package:qiitaapp/models/user.dart';
 import 'package:qiitaapp/Repository/qiita_repository.dart';
-import 'package:qiitaapp/Screens/article_screen.dart';
+import 'package:qiitaapp/screens/article_screen.dart';
+
+import '../Screens/top_screen.dart';
 
 class StockScreen extends StatefulWidget {
   StockScreen({Key? key}) : super(key: key);
@@ -49,7 +51,34 @@ class _StockScreenState extends State<StockScreen> {
                       }).toList(),
                     );
                   } else {
-                    return const Text("サインインするとストックが一覧表示されます。");
+                    return Center(
+                        child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Text("ログインするとストックした記事の一覧表示されます。"),
+                        const SizedBox(height: 8),
+                        TextButton(
+                          style: TextButton.styleFrom(
+                              backgroundColor: Colors.lightBlue,
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              side: const BorderSide(
+                                color: Colors.grey,
+                                width: 1,
+                              )),
+                          onPressed: () {
+                            Navigator.of(context).pushReplacement(
+                              MaterialPageRoute(
+                                  builder: (_) => const TopScreen()),
+                            );
+                          },
+                          child: const Text(
+                            "ログイン",
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        ),
+                      ],
+                    ));
                   }
                 },
               ),


### PR DESCRIPTION
ログインせずにホーム画面に遷移できるが、今まではプロフィールにプロフィール、ログアウトが押せた。
今回の修正からログインするボタンを表示させるように修正し、トップページに遷移させるようにした。
また、ストック一覧画面もログインしていない場合、テキスト表示されていたが、味気なかったので修正した。

![マイプロジェクト](https://user-images.githubusercontent.com/91385075/167054492-c7aafd7e-851f-4c56-83ca-aa397af372fb.png)

