### PR TITLE
不要なコメントの削除、記事カードを共通化

### DIFF
--- a/lib/Models/tag.dart
+++ b/lib/Models/tag.dart
@@ -1,13 +1,13 @@
 class Tag {
-  final int followers_count;
-  final String? icon_url;
+  final int followersCount;
+  final String? iconUrl;
   final String id;
-  final int items_count;
+  final int itemsCount;
 
   Tag({
-    required this.followers_count,
-    required this.icon_url,
+    required this.followersCount,
+    required this.iconUrl,
     required this.id,
-    required this.items_count,
+    required this.itemsCount,
   });
 }

--- a/lib/Models/user.dart
+++ b/lib/Models/user.dart
@@ -16,13 +16,4 @@ class User {
     required this.itemsCount,
     required this.followersCount,
   });
-
-  // User.fromJson(Map<String, dynamic> json)
-  //     : id = json['id'],
-  //       profileImageUrl = json['profile_image_url'];
-
-  // Map<String, dynamic> toJson() => {
-  //       'id': id,
-  //       'profile_image_url': profileImageUrl,
-  //     };
 }

--- a/lib/Repository/qiita_repository.dart
+++ b/lib/Repository/qiita_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:qiitaapp/client_id.dart';
 import 'package:qiitaapp/models/tag.dart';
@@ -68,7 +69,6 @@ class QiitaRepository {
     String? userID,
   }) async {
     String url = "https://qiita.com/api/v2/users/$userID/stocks?page=$page";
-    print(url);
     final response = await http.get(Uri.parse(url));
     if (response.statusCode == 404) {
       return [];
@@ -98,7 +98,6 @@ class QiitaRepository {
         }).toList(),
       );
     }).toList();
-    print(articleList.length);
     return articleList;
   }
 
@@ -205,14 +204,16 @@ class QiitaRepository {
     );
     final body = await jsonDecode(response.body);
     if (body is Map<String, dynamic>) {
-      print("リクエスト回数が超えてしまった。。。");
+      if (kDebugMode) {
+        print("リクエスト回数が超えてしまった。。。");
+      }
     }
     final tagsList = (body as List<dynamic>).map((item) {
       return Tag(
-        followers_count: item['followers_count'],
-        icon_url: item['icon_url'],
+        followersCount: item['followers_count'],
+        iconUrl: item['icon_url'],
         id: item['id'],
-        items_count: item['items_count'],
+        itemsCount: item['items_count'],
       );
     }).toList();
     return tagsList;

--- a/lib/Screens/article_list_screen.dart
+++ b/lib/Screens/article_list_screen.dart
@@ -7,6 +7,7 @@ import 'package:qiitaapp/models/articles.dart';
 import 'package:qiitaapp/screens/article_screen.dart';
 
 import '../Repository/qiita_repository.dart';
+import '../components/article_card.dart';
 
 class ArticleListScreen extends StatefulWidget {
   const ArticleListScreen({Key? key, this.searchString, this.tagID})
@@ -111,7 +112,7 @@ class _articleListView extends StatelessWidget {
             onTap: () => onTapArticle(article),
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 4),
-              child: articleCard(
+              child: ArticleCard(
                   title: article.title,
                   author: article.user.id,
                   profileImageIcon: article.user.profileImageUrl),
@@ -119,47 +120,6 @@ class _articleListView extends StatelessWidget {
           );
         },
         itemCount: articleList.length,
-      ),
-    );
-  }
-}
-
-class articleCard extends StatelessWidget {
-  const articleCard({
-    Key? key,
-    required this.title,
-    required this.author,
-    required this.profileImageIcon,
-  }) : super(key: key);
-
-  final String title;
-  final String author;
-  final String profileImageIcon;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      child: ListTile(
-        leading: Container(
-          width: 32,
-          height: 32,
-          child: ClipRRect(
-            child: FadeInImage(
-              placeholder: const AssetImage("assets/person_filled.png"),
-              image: NetworkImage(profileImageIcon),
-              imageErrorBuilder: (context, error, stackTrace) {
-                return Image.asset("assets/person_filled.png");
-              },
-            ),
-            borderRadius: BorderRadius.circular(8),
-          ),
-        ),
-        title: Text(
-          title,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-        subtitle: Text(author),
       ),
     );
   }

--- a/lib/Screens/article_screen.dart
+++ b/lib/Screens/article_screen.dart
@@ -160,7 +160,6 @@ class _TagList extends StatelessWidget {
                   style: const TextStyle(color: Colors.grey),
                 ),
                 onTap: () {
-                  print("article_screen: ${tag.name}");
                   Navigator.of(context).pushReplacement(MaterialPageRoute(
                       builder: (_) => TagResultsScreen(tagID: tag.name)));
                 },

--- a/lib/Screens/search_screen.dart
+++ b/lib/Screens/search_screen.dart
@@ -54,7 +54,7 @@ class _SearchScreenState extends State<SearchScreen> {
                             border: Border.all(color: Colors.black),
                           ),
                           padding: const EdgeInsets.all(8.0),
-                          child: Text("${searchOption}"),
+                          child: Text(searchOption),
                         ),
                       ),
                     ),
@@ -116,102 +116,97 @@ class _SearchScreenState extends State<SearchScreen> {
                     Container(
                       padding: const EdgeInsets.only(top: 8),
                       child: DataTable(
-                          sortAscending: false,
-                          columnSpacing: 0.0,
-                          headingRowHeight: 50.0,
-                          decoration:
-                              BoxDecoration(border: Border.all(width: 1)),
-                          columns: const [
-                            DataColumn(label: Text("項目")),
-                            DataColumn(label: Text("オプション")),
-                          ],
-                          rows: [
-                            DataRow(
-                              color:
-                                  MaterialStateProperty.resolveWith((states) {
-                                return Colors.grey[200];
-                              }),
-                              cells: const [
-                                DataCell(Text("タイトルに「2015」を含む")),
-                                DataCell(Text("title:2015")),
-                              ],
-                            ),
-                            const DataRow(
-                              cells: [
-                                DataCell(Text("本文に「Qiita」を含む")),
-                                DataCell(Text("body:Qiita")),
-                              ],
-                            ),
-                            DataRow(
-                              color:
-                                  MaterialStateProperty.resolveWith((states) {
-                                return Colors.grey[200];
-                              }),
-                              cells: const [
-                                DataCell(Text("コードに「Ruby」を含む")),
-                                DataCell(Text("code:Ruby")),
-                              ],
-                            ),
-                            const DataRow(
-                              cells: [
-                                DataCell(Text("「Ruby」タグが付く")),
-                                DataCell(Text("tag:Ruby")),
-                              ],
-                            ),
-                            DataRow(
-                              color:
-                                  MaterialStateProperty.resolveWith((states) {
-                                return Colors.grey[200];
-                              }),
-                              cells: const [
-                                DataCell(Text("sampleuserが作成した")),
-                                DataCell(Text("user:sampleuser")),
-                              ],
-                            ),
-                            const DataRow(
-                              cells: [
-                                DataCell(Text("「tag:Ruby」を含まない")),
-                                DataCell(Text("-tag:Ruby")),
-                              ],
-                            ),
-                            DataRow(
-                              color:
-                                  MaterialStateProperty.resolveWith((states) {
-                                return Colors.grey[200];
-                              }),
-                              cells: const [
-                                DataCell(Text("3件より多くストックされている")),
-                                DataCell(Text("stocks:>3")),
-                              ],
-                            ),
-                            const DataRow(
-                              cells: [
-                                DataCell(Text("2021-10-09以降に作成された")),
-                                DataCell(Text("created:>2021-10-09")),
-                              ],
-                            ),
-                            DataRow(
-                              color:
-                                  MaterialStateProperty.resolveWith((states) {
-                                return Colors.grey[200];
-                              }),
-                              cells: const [
-                                DataCell(Text("2021-10-01 以降に更新された")),
-                                DataCell(Text("updated:>2021-10")),
-                              ],
-                            ),
-                            const DataRow(
-                              cells: [
-                                DataCell(Text("「Go」または「AWS」を含む")),
-                                DataCell(Text("Go OR AWS")),
-                              ],
-                            ),
-                          ]),
+                        sortAscending: false,
+                        columnSpacing: 0.0,
+                        headingRowHeight: 50.0,
+                        decoration: BoxDecoration(border: Border.all(width: 1)),
+                        columns: const [
+                          DataColumn(label: Text("項目")),
+                          DataColumn(label: Text("オプション")),
+                        ],
+                        rows: [
+                          DataRow(
+                            color: MaterialStateProperty.resolveWith((states) {
+                              return Colors.grey[200];
+                            }),
+                            cells: const [
+                              DataCell(Text("タイトルに「2015」を含む")),
+                              DataCell(Text("title:2015")),
+                            ],
+                          ),
+                          const DataRow(
+                            cells: [
+                              DataCell(Text("本文に「Qiita」を含む")),
+                              DataCell(Text("body:Qiita")),
+                            ],
+                          ),
+                          DataRow(
+                            color: MaterialStateProperty.resolveWith((states) {
+                              return Colors.grey[200];
+                            }),
+                            cells: const [
+                              DataCell(Text("コードに「Ruby」を含む")),
+                              DataCell(Text("code:Ruby")),
+                            ],
+                          ),
+                          const DataRow(
+                            cells: [
+                              DataCell(Text("「Ruby」タグが付く")),
+                              DataCell(Text("tag:Ruby")),
+                            ],
+                          ),
+                          DataRow(
+                            color: MaterialStateProperty.resolveWith((states) {
+                              return Colors.grey[200];
+                            }),
+                            cells: const [
+                              DataCell(Text("sampleuserが作成した")),
+                              DataCell(Text("user:sampleuser")),
+                            ],
+                          ),
+                          const DataRow(
+                            cells: [
+                              DataCell(Text("「tag:Ruby」を含まない")),
+                              DataCell(Text("-tag:Ruby")),
+                            ],
+                          ),
+                          DataRow(
+                            color: MaterialStateProperty.resolveWith((states) {
+                              return Colors.grey[200];
+                            }),
+                            cells: const [
+                              DataCell(Text("3件より多くストックされている")),
+                              DataCell(Text("stocks:>3")),
+                            ],
+                          ),
+                          const DataRow(
+                            cells: [
+                              DataCell(Text("2021-10-09以降に作成された")),
+                              DataCell(Text("created:>2021-10-09")),
+                            ],
+                          ),
+                          DataRow(
+                            color: MaterialStateProperty.resolveWith((states) {
+                              return Colors.grey[200];
+                            }),
+                            cells: const [
+                              DataCell(Text("2021-10-01 以降に更新された")),
+                              DataCell(Text("updated:>2021-10")),
+                            ],
+                          ),
+                          const DataRow(
+                            cells: [
+                              DataCell(Text("「Go」または「AWS」を含む")),
+                              DataCell(Text("Go OR AWS")),
+                            ],
+                          ),
+                        ],
+                      ),
                     )
                   ],
                 ),
               ),
-            )
+            ),
           ],
         ),
       ),

--- a/lib/Screens/stock_screen.dart
+++ b/lib/Screens/stock_screen.dart
@@ -6,6 +6,7 @@ import 'package:qiitaapp/Repository/qiita_repository.dart';
 import 'package:qiitaapp/screens/article_screen.dart';
 
 import '../Screens/top_screen.dart';
+import '../components/article_card.dart';
 
 class StockScreen extends StatefulWidget {
   StockScreen({Key? key}) : super(key: key);
@@ -76,7 +77,7 @@ class _StockScreenState extends State<StockScreen> {
                                   ),
                                 );
                               },
-                              child: articleCard(
+                              child: ArticleCard(
                                 title: value.title,
                                 author: value.user.id,
                                 profileImageIcon: value.user.profileImageUrl,
@@ -106,46 +107,5 @@ class _StockScreenState extends State<StockScreen> {
   getStock() async {
     var user = await QiitaRepository().getAuthenticatedUser();
     return QiitaRepository().fetchUserArticleList(userID: user.id);
-  }
-}
-
-class articleCard extends StatelessWidget {
-  const articleCard({
-    Key? key,
-    required this.title,
-    required this.author,
-    required this.profileImageIcon,
-  }) : super(key: key);
-
-  final String title;
-  final String author;
-  final String profileImageIcon;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      child: ListTile(
-        leading: Container(
-          width: 32,
-          height: 32,
-          child: ClipRRect(
-            child: FadeInImage(
-              placeholder: const AssetImage("assets/person_filled.png"),
-              image: NetworkImage(profileImageIcon),
-              imageErrorBuilder: (context, error, stackTrace) {
-                return Image.asset("assets/person_filled.png");
-              },
-            ),
-            borderRadius: BorderRadius.circular(8),
-          ),
-        ),
-        title: Text(
-          title,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-        subtitle: Text(author),
-      ),
-    );
   }
 }

--- a/lib/Screens/tag_screen.dart
+++ b/lib/Screens/tag_screen.dart
@@ -30,7 +30,7 @@ class _TagScreenState extends State<TagScreen> {
                       height: 32,
                       child: ClipRRect(
                         child: Image.network(
-                          tagList[index].icon_url!,
+                          tagList[index].iconUrl!,
                           errorBuilder: (context, error, stackTrace) {
                             return const Icon(Icons.auto_awesome_mosaic);
                           },
@@ -41,7 +41,6 @@ class _TagScreenState extends State<TagScreen> {
                     title: Text(tagList[index].id),
                   ),
                   onTap: () {
-                    print("tag_screen: ${tagList[index].id}");
                     Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (_) =>

--- a/lib/Screens/top_screen.dart
+++ b/lib/Screens/top_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:qiitaapp/Repository/qiita_repository.dart';
 import 'package:qiitaapp/screens/home_screen.dart';
@@ -28,7 +29,9 @@ class _TopScreenState extends State<TopScreen> {
         _onAuthorizedCallbackIsCalled(event);
       }
     }, onError: (error) {
-      print("Error: ${error}");
+      if (kDebugMode) {
+        print("Error: $error");
+      }
     });
   }
 

--- a/lib/components/article_card.dart
+++ b/lib/components/article_card.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+class ArticleCard extends StatelessWidget {
+  const ArticleCard({
+    Key? key,
+    required this.title,
+    required this.author,
+    required this.profileImageIcon,
+  }) : super(key: key);
+
+  final String title;
+  final String author;
+  final String profileImageIcon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: Container(
+          width: 32,
+          height: 32,
+          child: ClipRRect(
+            child: FadeInImage(
+              placeholder: const AssetImage("assets/person_filled.png"),
+              image: NetworkImage(profileImageIcon),
+              imageErrorBuilder: (context, error, stackTrace) {
+                return Image.asset("assets/person_filled.png");
+              },
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+        title: Text(
+          title,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(author),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
使わなくなったコードをコメントアウトしていたり、print関数がそのまま残っていたので、削除した。
また、2つの画面で_articleCardという記事を表示させるWidgetがあったので、componentsフォルダを作って、その中article_card.dartを作成し、共通化させた。

また、検索画面にあるテーブルをきれいにしようと、1つのMapを参照してforEachでループしてコードを短くしようとしたが、forEachは返り値がvoid型なので無理だった。forにしようとしたが、DataTableのrowsの中でforを使おうとすると怒られたので、今回は見送り。
緊急というわけではないので、良いやり方を思いついたら、実装する。