### PR TITLE
記事内リンクが開けるように修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": true
+}

--- a/lib/Screens/article_screen.dart
+++ b/lib/Screens/article_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:qiitaapp/screens/tag_results_screen.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class ArticleScreen extends StatelessWidget {
   final Article article;
@@ -73,6 +74,10 @@ class ArticleScreen extends StatelessWidget {
               ),
               Html(
                 data: article.renderedBody,
+                onLinkTap: (String? url, RenderContext context,
+                    Map<String, String> attributes, Element) {
+                  url != null ? launch(url!) : print("not valid url");
+                },
                 style: {
                   'h2': Style(
                     border: const Border(


### PR DESCRIPTION
記事内にあるリンクテキストが押せそうな表示になっているのに、押してもリンク先に飛ばなかった。
なので、リンク先に飛ぶように修正した。

記事の表示には`flutter_html`を使っていて、その中にリンクを押した際の動作を指定するメソッドがあったので、それを使った。
リンク先がない場合には今まで通り何も反応しない。
リンク先がない場合の動作で、リンク先がない旨のメッセージが出るサービスは見たところないし、一旦このままにする。